### PR TITLE
DXP-1748: Enforce node type for pages

### DIFF
--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/AssetCandidate.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/AssetCandidate.java
@@ -1,58 +1,18 @@
 package dev.streamx.aem.connector.blueprints;
 
 import com.day.cq.dam.api.DamConstants;
-import java.util.Optional;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.nodetype.NodeType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.uri.SlingUri;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class AssetCandidate {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AssetCandidate.class);
-  private final SlingUri slingUri;
-  private final ResourceResolverFactory resourceResolverFactory;
+  private final NodeTypeCheck nodeTypeCheck;
 
   AssetCandidate(ResourceResolverFactory resourceResolverFactory, SlingUri slingUri) {
-    this.resourceResolverFactory = resourceResolverFactory;
-    this.slingUri = slingUri;
+    this.nodeTypeCheck = new NodeTypeCheck(resourceResolverFactory, slingUri);
   }
 
-  @SuppressWarnings({"squid:S1874", "deprecation"})
   boolean isAsset() {
-    try (
-        ResourceResolver resourceResolver
-            = resourceResolverFactory.getAdministrativeResourceResolver(null)
-    ) {
-      Resource resource = resourceResolver.resolve(slingUri.toString());
-      boolean isAsset = Optional.ofNullable(resource.adaptTo(Node.class))
-          .map(this::extractPrimaryNt)
-          .stream()
-          .anyMatch(primaryNT -> primaryNT.equals(DamConstants.NT_DAM_ASSET));
-      LOG.trace("Is '{}' an asset? Answer: {}", slingUri, isAsset);
-      return isAsset;
-    } catch (LoginException exception) {
-      String message = String.format("Can't determine if '%s' is an asset", slingUri);
-      LOG.error(message, exception);
-      return false;
-    }
-  }
-
-  private String extractPrimaryNt(Node node) {
-    try {
-      NodeType primaryNT = node.getPrimaryNodeType();
-      return primaryNT.getName();
-    } catch (RepositoryException exception) {
-      String message = String.format("Failed to extract primary node type for '%s'", node);
-      LOG.error(message, exception);
-      return StringUtils.EMPTY;
-    }
+    return nodeTypeCheck.matches(DamConstants.NT_DAM_ASSET);
   }
 }

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/NodeTypeCheck.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/NodeTypeCheck.java
@@ -1,0 +1,61 @@
+package dev.streamx.aem.connector.blueprints;
+
+import java.util.Optional;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NodeType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.uri.SlingUri;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class NodeTypeCheck {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NodeTypeCheck.class);
+  private final SlingUri slingUri;
+  private final ResourceResolverFactory resourceResolverFactory;
+
+  NodeTypeCheck(ResourceResolverFactory resourceResolverFactory, SlingUri slingUri) {
+    this.resourceResolverFactory = resourceResolverFactory;
+    this.slingUri = slingUri;
+  }
+
+  @SuppressWarnings({"squid:S1874", "deprecation"})
+  boolean matches(String expectedPrimaryNodeType) {
+    try (
+        ResourceResolver resourceResolver
+            = resourceResolverFactory.getAdministrativeResourceResolver(null)
+    ) {
+      Resource resource = resourceResolver.resolve(slingUri.toString());
+      boolean matches = Optional.ofNullable(resource.adaptTo(Node.class))
+          .map(this::extractPrimaryNt)
+          .stream()
+          .anyMatch(primaryNT -> primaryNT.equals(expectedPrimaryNodeType));
+      LOG.trace(
+          "Does {} have this node type: '{}'? Answer: {}", slingUri, expectedPrimaryNodeType, matches
+      );
+      return matches;
+    } catch (LoginException exception) {
+      String message = String.format(
+          "Can't check if %s is of this node type: %s", slingUri, expectedPrimaryNodeType
+      );
+      LOG.error(message, exception);
+      return false;
+    }
+  }
+
+  private String extractPrimaryNt(Node node) {
+    try {
+      NodeType primaryNT = node.getPrimaryNodeType();
+      return primaryNT.getName();
+    } catch (RepositoryException exception) {
+      String message = String.format("Failed to extract primary node type for '%s'", node);
+      LOG.error(message, exception);
+      return StringUtils.EMPTY;
+    }
+  }
+}

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PageCandidate.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PageCandidate.java
@@ -1,0 +1,42 @@
+package dev.streamx.aem.connector.blueprints;
+
+import com.adobe.aem.formsndocuments.util.FMConstants;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.uri.SlingUri;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PageCandidate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PageCandidate.class);
+
+  private final NodeTypeCheck nodeTypeCheck;
+  private final SlingUri slingUri;
+  private final String requiredPathRegex;
+  private final String excludedPathRegex;
+
+  PageCandidate(
+      ResourceResolverFactory resourceResolverFactory,
+      SlingUri slingUri,
+      String requiredPathRegex,
+      String excludedPathRegex
+  ) {
+    this.slingUri = slingUri;
+    this.nodeTypeCheck = new NodeTypeCheck(resourceResolverFactory, slingUri);
+    this.requiredPathRegex = requiredPathRegex;
+    this.excludedPathRegex = excludedPathRegex;
+  }
+
+  boolean isPage() {
+    boolean isPageNodeType = nodeTypeCheck.matches(FMConstants.CQ_PAGE_NODETYPE);
+    boolean isRequiredPath = slingUri.toString().matches(requiredPathRegex);
+    boolean isntExcludedPath = !slingUri.toString().matches(excludedPathRegex);
+    boolean isPage = isPageNodeType && isRequiredPath && isntExcludedPath;
+    LOG.trace(
+        "Is {} a page? Answer: {}. Is NodeType: {}. Is required path: {}. Isn't excluded path: {}",
+        slingUri, isPage, isPageNodeType, isRequiredPath, isntExcludedPath
+    );
+    return isPage;
+  }
+
+}

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PagePublicationHandler.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PagePublicationHandler.java
@@ -54,7 +54,7 @@ public class PagePublicationHandler implements PublicationHandler<Page> {
 
   @Override
   public boolean canHandle(String resourcePath) {
-    return enabled && pageDataService.isPage(resourcePath) && !resourcePath.contains("jcr:content");
+    return enabled && pageDataService.isPage(resourcePath);
   }
 
   @Override

--- a/blueprints/src/test/java/dev/streamx/aem/connector/blueprints/PageDataServiceTest.java
+++ b/blueprints/src/test/java/dev/streamx/aem/connector/blueprints/PageDataServiceTest.java
@@ -2,6 +2,8 @@ package dev.streamx.aem.connector.blueprints;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -83,6 +85,28 @@ class PageDataServiceTest {
         () -> assertEquals("<html><body><h1>Franklin Page</h1></body></html>", franklinMarkup),
         () -> assertEquals("<html><body><h1>Usual AEM Page</h1></body></html>", usualAEMMarkup),
         () -> assertEquals("<html><body><h1>Not Found</h1></body></html>", randomMarkup)
+    );
+  }
+
+  @Test
+  void mustCheckIfPage() {
+    PageDataService pageDataService = Optional.ofNullable(context.getService(PageDataService.class))
+        .orElseThrow();
+    @SuppressWarnings("resource")
+    ResourceResolver resourceResolver = context.resourceResolver();
+    Resource franklinPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/franklin-page")
+    ).orElseThrow();
+    Resource usualAEMPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/usual-aem-page")
+    ).orElseThrow();
+    Resource randomPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/random-page")
+    ).orElseThrow();
+    assertAll(
+        () -> assertTrue(pageDataService.isPage(franklinPageResource.getPath())),
+        () -> assertTrue(pageDataService.isPage(usualAEMPageResource.getPath())),
+        () -> assertFalse(pageDataService.isPage(randomPageResource.getPath()))
     );
   }
 }


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [ ] Non-breaking change
- [X] Bug fix / minor change

## 🛠 Changes being made

When checking if a given path is page, we must check the node type. Otherwise, some assets from "/content/<domain>" are pushed to the "pages" channel.

## ✅ Checklist

- [X] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [X] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
