### PR TITLE
DXP-1748 + DXP-1738: Node types and jobs

### DIFF
--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/AssetCandidate.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/AssetCandidate.java
@@ -1,58 +1,18 @@
 package dev.streamx.aem.connector.blueprints;
 
 import com.day.cq.dam.api.DamConstants;
-import java.util.Optional;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.nodetype.NodeType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.uri.SlingUri;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class AssetCandidate {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AssetCandidate.class);
-  private final SlingUri slingUri;
-  private final ResourceResolverFactory resourceResolverFactory;
+  private final NodeTypeCheck nodeTypeCheck;
 
   AssetCandidate(ResourceResolverFactory resourceResolverFactory, SlingUri slingUri) {
-    this.resourceResolverFactory = resourceResolverFactory;
-    this.slingUri = slingUri;
+    this.nodeTypeCheck = new NodeTypeCheck(resourceResolverFactory, slingUri);
   }
 
-  @SuppressWarnings({"squid:S1874", "deprecation"})
   boolean isAsset() {
-    try (
-        ResourceResolver resourceResolver
-            = resourceResolverFactory.getAdministrativeResourceResolver(null)
-    ) {
-      Resource resource = resourceResolver.resolve(slingUri.toString());
-      boolean isAsset = Optional.ofNullable(resource.adaptTo(Node.class))
-          .map(this::extractPrimaryNt)
-          .stream()
-          .anyMatch(primaryNT -> primaryNT.equals(DamConstants.NT_DAM_ASSET));
-      LOG.trace("Is '{}' an asset? Answer: {}", slingUri, isAsset);
-      return isAsset;
-    } catch (LoginException exception) {
-      String message = String.format("Can't determine if '%s' is an asset", slingUri);
-      LOG.error(message, exception);
-      return false;
-    }
-  }
-
-  private String extractPrimaryNt(Node node) {
-    try {
-      NodeType primaryNT = node.getPrimaryNodeType();
-      return primaryNT.getName();
-    } catch (RepositoryException exception) {
-      String message = String.format("Failed to extract primary node type for '%s'", node);
-      LOG.error(message, exception);
-      return StringUtils.EMPTY;
-    }
+    return nodeTypeCheck.matches(DamConstants.NT_DAM_ASSET);
   }
 }

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/NodeTypeCheck.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/NodeTypeCheck.java
@@ -1,0 +1,61 @@
+package dev.streamx.aem.connector.blueprints;
+
+import java.util.Optional;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NodeType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.uri.SlingUri;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class NodeTypeCheck {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NodeTypeCheck.class);
+  private final SlingUri slingUri;
+  private final ResourceResolverFactory resourceResolverFactory;
+
+  NodeTypeCheck(ResourceResolverFactory resourceResolverFactory, SlingUri slingUri) {
+    this.resourceResolverFactory = resourceResolverFactory;
+    this.slingUri = slingUri;
+  }
+
+  @SuppressWarnings({"squid:S1874", "deprecation"})
+  boolean matches(String expectedPrimaryNodeType) {
+    try (
+        ResourceResolver resourceResolver
+            = resourceResolverFactory.getAdministrativeResourceResolver(null)
+    ) {
+      Resource resource = resourceResolver.resolve(slingUri.toString());
+      boolean matches = Optional.ofNullable(resource.adaptTo(Node.class))
+          .map(this::extractPrimaryNt)
+          .stream()
+          .anyMatch(primaryNT -> primaryNT.equals(expectedPrimaryNodeType));
+      LOG.trace(
+          "Does {} have this node type: '{}'? Answer: {}", slingUri, expectedPrimaryNodeType, matches
+      );
+      return matches;
+    } catch (LoginException exception) {
+      String message = String.format(
+          "Can't check if %s is of this node type: %s", slingUri, expectedPrimaryNodeType
+      );
+      LOG.error(message, exception);
+      return false;
+    }
+  }
+
+  private String extractPrimaryNt(Node node) {
+    try {
+      NodeType primaryNT = node.getPrimaryNodeType();
+      return primaryNT.getName();
+    } catch (RepositoryException exception) {
+      String message = String.format("Failed to extract primary node type for '%s'", node);
+      LOG.error(message, exception);
+      return StringUtils.EMPTY;
+    }
+  }
+}

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PageCandidate.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PageCandidate.java
@@ -1,0 +1,42 @@
+package dev.streamx.aem.connector.blueprints;
+
+import com.adobe.aem.formsndocuments.util.FMConstants;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.uri.SlingUri;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PageCandidate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PageCandidate.class);
+
+  private final NodeTypeCheck nodeTypeCheck;
+  private final SlingUri slingUri;
+  private final String requiredPathRegex;
+  private final String excludedPathRegex;
+
+  PageCandidate(
+      ResourceResolverFactory resourceResolverFactory,
+      SlingUri slingUri,
+      String requiredPathRegex,
+      String excludedPathRegex
+  ) {
+    this.slingUri = slingUri;
+    this.nodeTypeCheck = new NodeTypeCheck(resourceResolverFactory, slingUri);
+    this.requiredPathRegex = requiredPathRegex;
+    this.excludedPathRegex = excludedPathRegex;
+  }
+
+  boolean isPage() {
+    boolean isPageNodeType = nodeTypeCheck.matches(FMConstants.CQ_PAGE_NODETYPE);
+    boolean isRequiredPath = slingUri.toString().matches(requiredPathRegex);
+    boolean isntExcludedPath = !slingUri.toString().matches(excludedPathRegex);
+    boolean isPage = isPageNodeType && isRequiredPath && isntExcludedPath;
+    LOG.trace(
+        "Is {} a page? Answer: {}. Is NodeType: {}. Is required path: {}. Isn't excluded path: {}",
+        slingUri, isPage, isPageNodeType, isRequiredPath, isntExcludedPath
+    );
+    return isPage;
+  }
+
+}

--- a/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PagePublicationHandler.java
+++ b/blueprints/src/main/java/dev/streamx/aem/connector/blueprints/PagePublicationHandler.java
@@ -54,7 +54,7 @@ public class PagePublicationHandler implements PublicationHandler<Page> {
 
   @Override
   public boolean canHandle(String resourcePath) {
-    return enabled && pageDataService.isPage(resourcePath) && !resourcePath.contains("jcr:content");
+    return enabled && pageDataService.isPage(resourcePath);
   }
 
   @Override

--- a/blueprints/src/test/java/dev/streamx/aem/connector/blueprints/PageDataServiceTest.java
+++ b/blueprints/src/test/java/dev/streamx/aem/connector/blueprints/PageDataServiceTest.java
@@ -2,6 +2,8 @@ package dev.streamx.aem.connector.blueprints;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -83,6 +85,28 @@ class PageDataServiceTest {
         () -> assertEquals("<html><body><h1>Franklin Page</h1></body></html>", franklinMarkup),
         () -> assertEquals("<html><body><h1>Usual AEM Page</h1></body></html>", usualAEMMarkup),
         () -> assertEquals("<html><body><h1>Not Found</h1></body></html>", randomMarkup)
+    );
+  }
+
+  @Test
+  void mustCheckIfPage() {
+    PageDataService pageDataService = Optional.ofNullable(context.getService(PageDataService.class))
+        .orElseThrow();
+    @SuppressWarnings("resource")
+    ResourceResolver resourceResolver = context.resourceResolver();
+    Resource franklinPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/franklin-page")
+    ).orElseThrow();
+    Resource usualAEMPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/usual-aem-page")
+    ).orElseThrow();
+    Resource randomPageResource = Optional.ofNullable(
+        resourceResolver.getResource("/content/random-page")
+    ).orElseThrow();
+    assertAll(
+        () -> assertTrue(pageDataService.isPage(franklinPageResource.getPath())),
+        () -> assertTrue(pageDataService.isPage(usualAEMPageResource.getPath())),
+        () -> assertFalse(pageDataService.isPage(randomPageResource.getPath()))
     );
   }
 }

--- a/cloud-pack/cloud-pack.config/src/main/content/jcr_root/apps/streamx-connector-aem-cloud-pack/osgiconfig/config.author/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~streamx-connector-blueprints.cfg.json
+++ b/cloud-pack/cloud-pack.config/src/main/content/jcr_root/apps/streamx-connector-aem-cloud-pack/osgiconfig/config.author/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~streamx-connector-blueprints.cfg.json
@@ -1,5 +1,6 @@
 {
   "whitelist.bundles": [
+    "streamx-connector-aem",
     "streamx-connector-aem-blueprints",
     "streamx-connector-sling"
   ],

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -52,6 +52,18 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/connector/src/test/java/dev/streamx/aem/connector/impl/AemReplicationEventHandlerTest.java
+++ b/connector/src/test/java/dev/streamx/aem/connector/impl/AemReplicationEventHandlerTest.java
@@ -1,0 +1,82 @@
+package dev.streamx.aem.connector.impl;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.day.cq.replication.ReplicationAction;
+import dev.streamx.sling.connector.IngestionTrigger;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.JobManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.service.event.Event;
+
+@ExtendWith({MockitoExtension.class, AemContextExtension.class})
+class AemReplicationEventHandlerTest {
+
+  private final AemContext context = new AemContext();
+
+  @Mock
+  private JobManager jobManager;
+
+  private AtomicReference<String> jobTopic;
+  private Map<String, Object> jobProps;
+  private AtomicInteger numberOfRuns;
+  private AemReplicationEventHandler handler;
+
+
+  @BeforeEach
+  void setup() {
+    jobTopic = new AtomicReference<>(StringUtils.EMPTY);
+    jobProps = Map.of();
+    numberOfRuns = new AtomicInteger();
+    when(jobManager.addJob(anyString(), anyMap())).then(
+        invocation -> {
+          jobTopic.set(invocation.getArgument(NumberUtils.INTEGER_ZERO));
+          jobProps = invocation.getArgument(NumberUtils.INTEGER_ONE);
+          numberOfRuns.incrementAndGet();
+          return mock(Job.class);
+        }
+    );
+    context.registerService(JobManager.class, jobManager);
+    handler = context.registerInjectActivateService(AemReplicationEventHandler.class);
+  }
+
+  @Test
+  void submitJob() {
+    Event event = new Event(
+        ReplicationAction.EVENT_TOPIC,
+        Map.of(
+            "type", "Activate",
+            "paths", new String[]{
+                "http://localhost:4502/content/we-retail/us/en",
+                "/content/wknd/us/en"
+            },
+            "userId", "admin"
+        )
+    );
+    handler.handleEvent(event);
+    assertAll(
+        () -> assertEquals(IngestionTrigger.JOB_TOPIC, jobTopic.get()),
+        () -> assertEquals(NumberUtils.INTEGER_ONE, numberOfRuns.get()),
+        () -> assertEquals(NumberUtils.INTEGER_TWO, jobProps.size()),
+        () -> assertTrue(jobProps.containsKey("streamx.ingestionAction")),
+        () -> assertTrue(jobProps.containsKey("streamx.urisToIngest"))
+    );
+  }
+}

--- a/connector/src/test/resources/logback-test.xml
+++ b/connector/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+<!--    &lt;!&ndash; Define a logger for the package "dev.streamx" &ndash;&gt;-->
+<!--    <logger name="dev.streamx" level="TRACE">-->
+<!--        <appender-ref ref="STDOUT"/>-->
+<!--    </logger>-->
+
+    <!-- Disable logging for all other packages -->
+    <root level="OFF">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <streamx-connector-sling.version>0.2.8</streamx-connector-sling.version>
+    <streamx-connector-sling.version>0.2.9-SNAPSHOT</streamx-connector-sling.version>
     <org.apache.sling.servlet-helpers.version>1.4.6</org.apache.sling.servlet-helpers.version>
     <junit-bom.version>5.10.2</junit-bom.version>
     <mockito-junit-jupiter.version>5.12.0</mockito-junit-jupiter.version>


### PR DESCRIPTION
## 📋 Type of the Changes

- [ ] Breaking change
- [X] Non-breaking change
- [ ] Bug fix / minor change

## 🛠 Changes being made

DXP-1748: StreamX ingestion must be done in jobs, not in the event thread. 

DXP-1738: When checking if a given path is page, we must check the node type. Otherwise, some assets from "/content/" are pushed to the "pages" channel.

## ✅ Checklist

- [X] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [X] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
